### PR TITLE
Feat: Add backend API endpoints for searching with pagination and filters, and recommending games via dataset

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,97 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Depends, Query
+from fastapi.middleware.cors import CORSMiddleware
 
-app = FastAPI()
+from src.data_loader import SteamDataLoader
+from src.models import GameResponse, RecommendationRequest, RecommendationResponse
+from src.recommender import GameRecommender
+from src.utils import setup_logging, dataframe_to_dict_list, validate_game_data
+from src.config import DEBUG
 
-@app.get("/")
-def hello():
-    return {"message": "Hello World"}
+setup_logging("DEBUG" if DEBUG else "INFO")
+app = FastAPI(title="Steam Games Recommender", version="1.0")
+
+app.add_middleware(
+    CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"]
+)
+
+data_loader: SteamDataLoader
+recommender: GameRecommender
+
+@app.on_event("startup")
+async def startup():
+    global data_loader, recommender
+    data_loader = SteamDataLoader()
+    df = data_loader.processed_df
+    if not validate_game_data(df):
+        raise RuntimeError("Validation failed")
+    recommender = GameRecommender(df)
+
+def get_loader() -> SteamDataLoader:
+    if not data_loader:
+        raise HTTPException(500, "Loader not ready")
+    return data_loader
+
+def get_recommender() -> GameRecommender:
+    if not recommender:
+        raise HTTPException(500, "Recommender not ready")
+    return recommender
+
+@app.get("/games", response_model=list[GameResponse])
+async def get_games(
+    limit: int = Query(10, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    q: str | None = None,
+    price_min: float | None = None,
+    price_max: float | None = None,
+    min_metacritic: int | None = None,
+    min_review_score: float | None = None,
+    min_reviews: int | None = None,
+    genres: str | None = None,
+    categories: str | None = None,
+    platforms: str | None = None,
+    max_age_rating: int | None = None,
+    sort_by: str = "relevance",
+    sort_order: str = "desc",
+    loader: SteamDataLoader = Depends(get_loader),
+):
+    df = loader.query_games(
+        limit,
+        offset,
+        q,
+        price_min,
+        price_max,
+        None,
+        min_metacritic,
+        min_review_score,
+        min_reviews,
+        genres,
+        categories,
+        platforms,
+        max_age_rating,
+        sort_by,
+        sort_order,
+    )
+    return dataframe_to_dict_list(df)
+
+@app.get("/games/{appid}", response_model=GameResponse)
+async def get_one(appid: int, loader: SteamDataLoader = Depends(get_loader)):
+    df = loader.processed_df
+    row = df[df["appid"] == appid]
+    if row.empty:
+        raise HTTPException(404, "Game not found")
+    return row.iloc[0].to_dict()
+
+@app.post("/recommend", response_model=RecommendationResponse)
+async def recommend(
+    req: RecommendationRequest, rec: GameRecommender = Depends(get_recommender)
+):
+    result = rec.find_similar_games(req.game_name, req.max_recommendations)
+    if not result:
+        raise HTTPException(404, "Game not found")
+    target, recs = result
+    return RecommendationResponse(
+        query_game=target.to_dict(),
+        recommendations=dataframe_to_dict_list(recs),
+        total_found=len(recs),
+        recommendation_metadata=req.dict(exclude={"game_name", "max_recommendations"}),
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+pandas==2.2.3
+numpy>=2.0.0,<3.0.0
+scikit-learn>=1.3.2,<2.0.0
+pydantic==2.10.3
+python-multipart==0.0.12

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -1,0 +1,33 @@
+"""Configuration settings for the Steam Games Recommender"""
+from pathlib import Path
+
+# Base paths
+BASE_DIR = Path(__file__).parent.parent
+DATA_DIR = BASE_DIR / "data"
+
+# Now pointing to steam_games.csv
+CSV_FILE_PATH = DATA_DIR / "steam_games.csv"
+
+# API Configuration
+API_HOST = "0.0.0.0"
+API_PORT = 8000
+DEBUG = True
+
+# Recommendation settings
+DEFAULT_RECOMMENDATIONS = 5
+MAX_RECOMMENDATIONS = 20
+
+# Feature weights for recommendations
+PRICE_WEIGHT = 0.3
+RECENCY_WEIGHT = 0.2
+POPULARITY_WEIGHT = 0.3
+AGE_RATING_WEIGHT = 0.2
+
+# Price categories
+PRICE_CATEGORIES = {
+    "Free": (0, 0),
+    "Budget": (0.01, 5.00),
+    "Mid-range": (5.01, 20.00),
+    "Premium": (20.01, 60.00),
+    "Expensive": (60.01, float('inf'))
+}

--- a/backend/src/data_loader.py
+++ b/backend/src/data_loader.py
@@ -1,0 +1,132 @@
+import ast
+from pathlib import Path
+import logging
+
+import pandas as pd
+import numpy as np
+
+from .config import CSV_FILE_PATH
+
+logger = logging.getLogger(__name__)
+
+LIST_COLS = ["developers", "publishers", "genres", "categories"]
+DICT_COLS = ["tags"]
+
+class SteamDataLoader:
+    def __init__(self, csv_path: Path = CSV_FILE_PATH):
+        self.csv_path = csv_path
+        self.df = self.load_data()
+        self.processed_df = self.preprocess_data()
+
+    def load_data(self) -> pd.DataFrame:
+        if not self.csv_path.exists():
+            raise FileNotFoundError(f"{self.csv_path} not found")
+        df = pd.read_csv(self.csv_path, low_memory=False)
+        logger.info(f"Loaded {len(df)} records from {self.csv_path}")
+        return df
+
+    def _safe_parse_list(self, val):
+        if pd.isna(val) or val == "" or val == "[]":
+            return []
+        try:
+            return list(ast.literal_eval(val))
+        except Exception:
+            # fallback: comma-split
+            return [v.strip() for v in str(val).split(",") if v.strip()]
+
+    def _safe_parse_dict(self, val):
+        if pd.isna(val) or val == "" or val == "{}":
+            return {}
+        try:
+            return dict(ast.literal_eval(val))
+        except Exception:
+            return {}
+
+    def preprocess_data(self) -> pd.DataFrame:
+        df = self.df.copy()
+
+        # 1) Parse all list columns
+        for col in LIST_COLS:
+            if col in df.columns:
+                df[col] = df[col].apply(self._safe_parse_list)
+
+        # 2) Parse all dict columns
+        for col in DICT_COLS:
+            if col in df.columns:
+                df[col] = df[col].apply(self._safe_parse_dict)
+
+        # 3) Compute a review_score (%) so you can filter on `min_review_score`
+        if "positive" in df.columns and "negative" in df.columns:
+            total = df["positive"] + df["negative"]
+            df["review_score"] = (df["positive"] / total * 100).fillna(0)
+        else:
+            df["review_score"] = 0.0
+
+        self.processed_df = df
+        logger.info(f"Preprocessed data: {len(df)} games ready")
+        return df
+
+    def query_games(
+        self,
+        limit=10,
+        offset=0,
+        q=None,
+        price_min=None,
+        price_max=None,
+        price_category=None,
+        min_metacritic=None,
+        min_review_score=None,
+        min_reviews=None,
+        genres=None,
+        categories=None,
+        platforms=None,
+        max_age_rating=None,
+        sort_by="relevance",
+        sort_order="desc",
+    ) -> pd.DataFrame:
+        df = self.processed_df.copy()
+
+        # full-text search
+        if q:
+            df = df[df["name"].str.contains(q, case=False, na=False)]
+
+        # numeric filters
+        if price_min is not None:
+            df = df[df["price"] >= price_min]
+        if price_max is not None:
+            df = df[df["price"] <= price_max]
+        if min_metacritic is not None:
+            df = df[df["metacritic_score"] >= min_metacritic]
+        if min_review_score is not None:
+            df = df[df["review_score"] >= min_review_score]
+        if min_reviews is not None:
+            df = df[df["total_reviews"] >= min_reviews]
+        if max_age_rating is not None:
+            df = df[df["required_age"] <= max_age_rating]
+
+        # comma-separated list filters
+        def split_param(s):
+            return [v.strip() for v in s.split(",")] if s else []
+
+        for name, col in [("genres", "genres"), ("categories", "categories")]:
+            vals = split_param(locals()[name])
+            if vals and col in df.columns:
+                df = df[df[col].apply(lambda lst: any(v in lst for v in vals))]
+
+        # platforms assumed boolean columns
+        plats = split_param(platforms)
+        if plats:
+            mask = pd.Series(False, index=df.index)
+            for p in plats:
+                key = p.lower()
+                if key in df.columns:
+                    mask |= df[key].fillna(False)
+            df = df[mask]
+
+        # sorting
+        if sort_by != "relevance" and sort_by in df.columns:
+            asc = sort_order.lower() == "asc"
+            df = df.sort_values(sort_by, ascending=asc)
+
+        # pagination
+        return df.iloc[offset : offset + limit]

--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -1,0 +1,178 @@
+"""Pydantic models for API requests and responses - Updated for actual Steam data structure"""
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+from datetime import datetime
+
+class GameBase(BaseModel):
+    """Base game model with core fields"""
+    appid: int
+    name: str
+    price: float = 0.0
+    required_age: int = 0
+    release_date: Optional[datetime] = None
+
+class Game(GameBase):
+    """Extended game model with recommendation-relevant fields"""
+    # Core game info
+    short_description: Optional[str] = None
+    detailed_description: Optional[str] = None
+    
+    # Platform support
+    windows: Optional[bool] = None
+    mac: Optional[bool] = None
+    linux: Optional[bool] = None
+    
+    # Quality metrics
+    metacritic_score: Optional[int] = None
+    positive: Optional[int] = None
+    negative: Optional[int] = None
+    pct_pos_total: Optional[float] = None
+    num_reviews_total: Optional[int] = None
+    
+    # Engagement metrics
+    estimated_owners: Optional[str] = None
+    average_playtime_forever: Optional[int] = None
+    median_playtime_forever: Optional[int] = None
+    peak_ccu: Optional[int] = None
+    
+    # Content categorization
+    developers: Optional[List[str]] = None
+    publishers: Optional[List[str]] = None
+    categories: Optional[List[str]] = None
+    genres: Optional[List[str]] = None
+    tags: Optional[Dict[str, int]] = None  # Tag name -> count
+    
+    # Computed features (for recommendations)
+    price_category: Optional[str] = None
+    release_year: Optional[int] = None
+    popularity_score: Optional[float] = None
+    recency_score: Optional[float] = None
+    review_score: Optional[float] = None  # Derived from positive/negative reviews
+    
+class GameResponse(Game):
+    """Game response model with proper serialization"""
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat() if v else None
+        }
+
+class GameFeatures(BaseModel):
+    """Model specifically for AI features extraction"""
+    # Identifiers
+    appid: int
+    name: str
+    
+    # Numerical features for ML
+    price: float = 0.0
+    required_age: int = 0
+    metacritic_score: Optional[float] = None
+    positive_reviews: int = 0
+    negative_reviews: int = 0
+    review_ratio: float = 0.0  # positive / total reviews
+    total_reviews: int = 0
+    average_playtime: int = 0
+    peak_concurrent_users: int = 0
+    release_year: int = 2000
+    years_since_release: float = 0.0
+    
+    # Categorical features
+    price_category: str = "Unknown"
+    primary_genre: Optional[str] = None
+    platform_count: int = 0  # Number of supported platforms
+    
+    # Text features for NLP
+    description_text: str = ""
+    genres_text: str = ""  # Comma-separated genres
+    categories_text: str = ""  # Comma-separated categories
+    tags_text: str = ""  # Top tags as text
+    
+    # Popularity indicators
+    estimated_owners_numeric: float = 0.0  # Converted from range to midpoint
+    popularity_tier: str = "Low"  # Low, Medium, High based on reviews/owners
+
+class RecommendationRequest(BaseModel):
+    """Request model for recommendations"""
+    game_name: str = Field(..., description="Name of the game to find similar games for")
+    max_recommendations: int = Field(5, ge=1, le=20, description="Maximum number of recommendations")
+    
+    # Recommendation parameters
+    price_tolerance: float = Field(0.3, ge=0, le=1, description="Price tolerance (0-1)")
+    genre_weight: float = Field(0.4, ge=0, le=1, description="Weight for genre similarity")
+    review_weight: float = Field(0.3, ge=0, le=1, description="Weight for review scores")
+    popularity_weight: float = Field(0.2, ge=0, le=1, description="Weight for popularity")
+    recency_weight: float = Field(0.1, ge=0, le=1, description="Weight for game recency")
+    
+    # Filters
+    min_review_count: int = Field(10, ge=0, description="Minimum number of reviews")
+    exclude_adult: bool = Field(True, description="Exclude adult-rated games")
+    platforms: Optional[List[str]] = Field(None, description="Required platforms (windows, mac, linux)")
+
+class RecommendationResponse(BaseModel):
+    """Response model for recommendations"""
+    query_game: GameResponse
+    recommendations: List[GameResponse]
+    total_found: int
+    recommendation_metadata: Dict[str, Any] = Field(default_factory=dict)
+
+class SearchRequest(BaseModel):
+    """Request model for game search"""
+    query: str = Field(..., description="Search query")
+    limit: int = Field(10, ge=1, le=100, description="Maximum number of results")
+    
+    # Price filters
+    price_min: Optional[float] = Field(None, ge=0, description="Minimum price filter")
+    price_max: Optional[float] = Field(None, ge=0, description="Maximum price filter")
+    price_category: Optional[str] = Field(None, description="Price category filter")
+    
+    # Quality filters
+    min_metacritic: Optional[int] = Field(None, ge=0, le=100, description="Minimum Metacritic score")
+    min_review_score: Optional[float] = Field(None, ge=0, le=100, description="Minimum review percentage")
+    min_reviews: Optional[int] = Field(None, ge=0, description="Minimum number of reviews")
+    
+    # Content filters
+    genres: Optional[List[str]] = Field(None, description="Filter by genres")
+    categories: Optional[List[str]] = Field(None, description="Filter by categories")
+    platforms: Optional[List[str]] = Field(None, description="Required platforms")
+    max_age_rating: Optional[int] = Field(None, description="Maximum age rating")
+    
+    # Sorting
+    sort_by: str = Field("relevance", description="Sort by: relevance, price, reviews, playtime, release_date")
+    sort_order: str = Field("desc", description="Sort order: asc, desc")
+
+class StatsResponse(BaseModel):
+    """Response model for dataset statistics"""
+    total_games: int
+    
+    # Price statistics
+    price_stats: Dict[str, float]  # min, max, mean, median
+    price_distribution: Dict[str, int]  # by category
+    
+    # Review statistics
+    review_stats: Dict[str, float]
+    
+    # Release year statistics
+    release_year_stats: Dict[str, int]
+    
+    # Platform statistics
+    platform_stats: Dict[str, int]
+    
+    # Genre statistics
+    top_genres: Dict[str, int]
+    
+    # Tag statistics
+    top_tags: Dict[str, int]
+
+class BulkGameFeaturesResponse(BaseModel):
+    """Response model for bulk feature extraction (for AI team)"""
+    games: List[GameFeatures]
+    feature_columns: List[str]  # List of numerical feature column names
+    categorical_columns: List[str]  # List of categorical feature column names
+    text_columns: List[str]  # List of text feature column names
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+class SimilarityMatrix(BaseModel):
+    """Model for similarity matrix data"""
+    game_ids: List[int]
+    similarity_scores: List[List[float]]
+    feature_weights: Dict[str, float]
+    method: str  # cosine, euclidean, etc.

--- a/backend/src/recommender.py
+++ b/backend/src/recommender.py
@@ -1,0 +1,114 @@
+"""Game recommendation engine"""
+import pandas as pd
+import numpy as np
+from typing import Optional, Tuple
+from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.preprocessing import StandardScaler
+import logging
+
+from .models import Game, RecommendationRequest
+from .config import DEFAULT_RECOMMENDATIONS
+
+logger = logging.getLogger(__name__)
+
+class GameRecommender:
+    """Steam games recommendation engine"""
+    
+    def __init__(self, df: pd.DataFrame):
+        self.df = df.copy()
+        self.features = None
+        self.scaler = StandardScaler()
+        self._prepare_features()
+    
+    def _prepare_features(self):
+        """Prepare feature matrix for similarity calculations"""
+        # Select numeric features for similarity
+        feature_columns = ['price', 'required_age', 'popularity_score', 'recency_score']
+        available_features = [col for col in feature_columns if col in self.df.columns]
+        
+        if not available_features:
+            logger.warning("No numeric features available for recommendations")
+            return
+        
+        # Create feature matrix
+        self.features = self.df[available_features].fillna(0)
+        
+        # Scale features
+        self.features = self.scaler.fit_transform(self.features)
+        
+        logger.info(f"Prepared feature matrix with {len(available_features)} features")
+    
+    def find_similar_games(self, game_name: str, n_recommendations: int = DEFAULT_RECOMMENDATIONS) -> Optional[Tuple[pd.Series, pd.DataFrame]]:
+        """Find games similar to the given game"""
+        # Find the target game
+        game_mask = self.df['name'].str.contains(game_name, case=False, na=False)
+        
+        if not game_mask.any():
+            logger.warning(f"Game '{game_name}' not found")
+            return None
+        
+        target_idx = game_mask.idxmax()
+        target_game = self.df.loc[target_idx]
+        
+        if self.features is None:
+            # Fallback to category-based recommendations
+            return self._category_based_recommendations(target_game, n_recommendations)
+        
+        # Calculate similarity using cosine similarity
+        target_features = self.features[target_idx].reshape(1, -1)
+        similarities = cosine_similarity(target_features, self.features)[0]
+        
+        # Get similar games (excluding the target game)
+        similar_indices = np.argsort(similarities)[::-1]
+        similar_indices = similar_indices[similar_indices != target_idx]
+        
+        # Get top N recommendations
+        top_indices = similar_indices[:n_recommendations]
+        recommendations = self.df.loc[top_indices].copy()
+        recommendations['similarity_score'] = similarities[top_indices]
+        
+        logger.info(f"Found {len(recommendations)} similar games for '{game_name}'")
+        return target_game, recommendations
+    
+    def _category_based_recommendations(self, target_game: pd.Series, n_recommendations: int) -> Tuple[pd.Series, pd.DataFrame]:
+        """Fallback recommendation method based on categories"""
+        # Find games in the same price category
+        same_category = self.df[
+            (self.df['price_category'] == target_game.get('price_category')) &
+            (self.df.index != target_game.name)
+        ]
+        
+        # If same age rating is available, filter by it
+        if 'required_age' in self.df.columns and pd.notna(target_game.get('required_age')):
+            same_category = same_category[
+                same_category['required_age'] == target_game['required_age']
+            ]
+        
+        # Sort by popularity if available
+        if 'popularity_score' in same_category.columns:
+            same_category = same_category.sort_values('popularity_score', ascending=False)
+        
+        recommendations = same_category.head(n_recommendations).copy()
+        recommendations['similarity_score'] = 0.5  # Default similarity
+        
+        return target_game, recommendations
+    
+    def search_games(self, query: str, limit: int = 10, price_min: Optional[float] = None, price_max: Optional[float] = None, category: Optional[str] = None) -> pd.DataFrame:
+        """Search for games based on query and filters"""
+        # Start with name-based search
+        mask = self.df['name'].str.contains(query, case=False, na=False)
+        
+        # Apply filters
+        if price_min is not None:
+            mask = mask & (self.df['price'] >= price_min)
+        
+        if price_max is not None:
+            mask = mask & (self.df['price'] <= price_max)
+        
+        if category is not None:
+            mask = mask & (self.df['price_category'] == category)
+        
+        results = self.df[mask].head(limit)
+        logger.info(f"Search '{query}' returned {len(results)} results")
+        
+        return results

--- a/backend/src/utils.py
+++ b/backend/src/utils.py
@@ -1,0 +1,45 @@
+"""Utility functions"""
+import pandas as pd
+from typing import Dict, Any, List
+import logging
+
+logger = logging.getLogger(__name__)
+
+def setup_logging(level: str = "INFO"):
+    """Setup logging configuration"""
+    logging.basicConfig(
+        level=getattr(logging, level.upper()),
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+def dataframe_to_dict_list(df: pd.DataFrame) -> List[Dict[str, Any]]:
+    """Convert DataFrame to list of dictionaries"""
+    return df.to_dict('records')
+
+def validate_game_data(df: pd.DataFrame) -> bool:
+    """Validate that the dataframe has required columns"""
+    required_columns = ['name']
+    missing_columns = [col for col in required_columns if col not in df.columns]
+    
+    if missing_columns:
+        logger.error(f"Missing required columns: {missing_columns}")
+        return False
+    
+    if len(df) == 0:
+        logger.error("Dataset is empty")
+        return False
+    
+    return True
+
+def clean_string(text: str) -> str:
+    """Clean string for search/comparison"""
+    if pd.isna(text):
+        return ""
+    return str(text).strip().lower()
+
+def format_price(price: float) -> str:
+    """Format price for display"""
+    if pd.isna(price) or price == 0:
+        return "Free"
+    return f"${price:.2f}"


### PR DESCRIPTION
The purpose of this PR is, adding backend API endpoints for searching with pagination and filters, and recommending games using [Steam Games Dataset 2025 from Kaggle](https://www.kaggle.com/datasets/artermiloff/steam-games-dataset). 

Note: I didn't include the CSV file in this PR.